### PR TITLE
convert regex to raw string

### DIFF
--- a/libs/TGUtils.py
+++ b/libs/TGUtils.py
@@ -1,7 +1,7 @@
 import re
 
 def does_addr_match_res_definition(resource_definition,addr):
-    regex_definition = resource_definition.replace(".","\.").replace("*",".*").replace("?",".?")
+    regex_definition = resource_definition.replace(".",r"\.").replace("*",".*").replace("?",".?")
     x = re.search(regex_definition, addr)
     if x:
         #print(x[0])


### PR DESCRIPTION
This is a very simple fix for a bit of an edge case. For whatever reason, when trying to run the CLI in a container, I was getting the following warning from python:

`/Twingate-CLI/libs/TGUtils.py:4: SyntaxWarning: invalid escape sequence '\.'`

Making python interpret it as a raw string seems to clear that up. It may be wise to apply the same thing to the other regexes, although the `\` character seems to be the only thing it complains about.