### PR TITLE
Add device posture command with TrustProviderVerification support

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,15 @@ The output format can be set to CSV, DF (DataFrame) or JSON (Default) by using t
     * revoke
     * delete
     * rename
-    
+
+  * posture
+    * list: list all configured device posture checks
+    * show: show a specific posture check by ID
+    * create: create a new posture check
+    * update: update name, action, status, or description of a posture check
+    * delete: delete a posture check
+    * check: fetch the live posture status of a specific device, including all property checks and TrustProviderVerification results (CrowdStrike, Jamf, Kandji, Intune, SentinelOne, 1Password, manual)
+
 
 ## Examples
 ```
@@ -170,4 +178,40 @@ python ./tgcli.py -s RedPeacock device updateTrust -i "XXXabcNlOjE5MzI2OQ==" -t 
 ```
 # Update trust for a list of devices (and set them to Untrusted)
 python ./tgcli.py -s RedPeacock device updateTrust -l "XXXabcNlOjE5MzI2OQ==,YYYxyzFg4gT4SfC65K==" -t False
+```
+
+```
+# List all configured posture checks
+python ./tgcli.py -s RedPeacock posture list
+```
+
+```
+# Show details of a specific posture check
+python ./tgcli.py -s RedPeacock posture show -i "XXXabcNlOjE5MzI2OQ=="
+```
+
+```
+# Create a new posture check
+python ./tgcli.py -s RedPeacock posture create -n "Require Firewall" -t FIREWALL -a BLOCK_ACCESS -d "Block devices without firewall enabled"
+```
+
+```
+# Update a posture check (disable it)
+python ./tgcli.py -s RedPeacock posture update -i "XXXabcNlOjE5MzI2OQ==" -s DISABLED
+```
+
+```
+# Delete a posture check
+python ./tgcli.py -s RedPeacock posture delete -i "XXXabcNlOjE5MzI2OQ=="
+```
+
+```
+# Check the live posture status of a device (includes TrustProviderVerification for
+# CrowdStrike, Jamf, Kandji, Intune, SentinelOne, 1Password, and manual verification)
+python ./tgcli.py -s RedPeacock posture check -i "XXXabcNlOjE5MzI2OQ=="
+```
+
+```
+# Check live device posture and display as DataFrame
+python ./tgcli.py -s RedPeacock -f DF posture check -i "XXXabcNlOjE5MzI2OQ=="
 ```

--- a/logics/DevicePostureLogics.py
+++ b/logics/DevicePostureLogics.py
@@ -1,0 +1,204 @@
+import requests
+import json
+import sys
+import os
+
+sys.path.insert(1, './libs')
+sys.path.insert(1, './transformers')
+import GenericTransformers
+import DevicePostureTransformers
+import StdAPIUtils
+
+
+def get_posture_list_resources(token, JsonData):
+    Headers = StdAPIUtils.get_api_call_headers(token)
+    api_call_type = "POST"
+    variables = {"cursor": JsonData['cursor']}
+
+    Body = """
+    query ListDevicePostureChecks($cursor: String!) {
+        devicePostureChecks(after: $cursor) {
+            pageInfo {
+                endCursor
+                hasNextPage
+            }
+            edges {
+                node {
+                    id
+                    name
+                    description
+                    type
+                    action
+                    status
+                    createdAt
+                    updatedAt
+                }
+            }
+        }
+    }
+    """
+    return True, api_call_type, Headers, Body, variables
+
+
+def get_posture_show_resources(token, JsonData):
+    Headers = StdAPIUtils.get_api_call_headers(token)
+    api_call_type = "POST"
+    variables = {"checkID": JsonData['itemid']}
+
+    Body = """
+    query GetDevicePostureCheck($checkID: ID!) {
+        devicePostureCheck(id: $checkID) {
+            id
+            name
+            description
+            type
+            action
+            status
+            createdAt
+            updatedAt
+        }
+    }
+    """
+    return True, api_call_type, Headers, Body, variables
+
+
+def get_posture_create_resources(token, JsonData):
+    Headers = StdAPIUtils.get_api_call_headers(token)
+    api_call_type = "POST"
+    variables = {
+        "name": JsonData['name'],
+        "description": JsonData.get('description', ''),
+        "type": JsonData['type'],
+        "action": JsonData['action'],
+    }
+
+    Body = """
+    mutation CreateDevicePostureCheck(
+        $name: String!,
+        $description: String,
+        $type: DevicePostureCheckType!,
+        $action: DevicePostureCheckAction!
+    ) {
+        devicePostureCheckCreate(
+            name: $name,
+            description: $description,
+            type: $type,
+            action: $action
+        ) {
+            ok
+            error
+            entity {
+                id
+                name
+                description
+                type
+                action
+                status
+            }
+        }
+    }
+    """
+    return True, api_call_type, Headers, Body, variables
+
+
+def get_posture_update_resources(token, JsonData):
+    Headers = StdAPIUtils.get_api_call_headers(token)
+    api_call_type = "POST"
+    variables = {"checkID": JsonData['itemid']}
+
+    if JsonData.get('name'):
+        variables['name'] = JsonData['name']
+    if JsonData.get('description') is not None:
+        variables['description'] = JsonData['description']
+    if JsonData.get('action'):
+        variables['action'] = JsonData['action']
+    if JsonData.get('status'):
+        variables['status'] = JsonData['status']
+
+    Body = """
+    mutation UpdateDevicePostureCheck(
+        $checkID: ID!,
+        $name: String,
+        $description: String,
+        $action: DevicePostureCheckAction,
+        $status: DevicePostureCheckStatus
+    ) {
+        devicePostureCheckUpdate(
+            id: $checkID,
+            name: $name,
+            description: $description,
+            action: $action,
+            status: $status
+        ) {
+            ok
+            error
+            entity {
+                id
+                name
+                description
+                type
+                action
+                status
+            }
+        }
+    }
+    """
+    return True, api_call_type, Headers, Body, variables
+
+
+def get_posture_delete_resources(token, JsonData):
+    Headers = StdAPIUtils.get_api_call_headers(token)
+    api_call_type = "POST"
+    variables = {"checkID": JsonData['itemid']}
+
+    Body = """
+    mutation DeleteDevicePostureCheck($checkID: ID!) {
+        devicePostureCheckDelete(id: $checkID) {
+            ok
+            error
+        }
+    }
+    """
+    return True, api_call_type, Headers, Body, variables
+
+
+def item_list(outputFormat, sessionname):
+    ListOfResponses = []
+    hasMorePages = True
+    Cursor = "0"
+    while hasMorePages:
+        j = StdAPIUtils.generic_api_call_handler(sessionname, get_posture_list_resources, {'cursor': Cursor})
+        hasMorePages, Cursor = GenericTransformers.CheckIfMorePages(j, 'devicePostureChecks')
+        ListOfResponses.append(j['data']['devicePostureChecks']['edges'])
+    output, r = StdAPIUtils.format_output(ListOfResponses, outputFormat, DevicePostureTransformers.GetListAsCsv)
+    print(output)
+
+
+def item_show(outputFormat, sessionname, itemid):
+    j = StdAPIUtils.generic_api_call_handler(sessionname, get_posture_show_resources, {'itemid': itemid})
+    output, r = StdAPIUtils.format_output(j, outputFormat, DevicePostureTransformers.GetShowAsCsv)
+    print(output)
+
+
+def item_create(outputFormat, sessionname, name, check_type, action, description):
+    j = StdAPIUtils.generic_api_call_handler(
+        sessionname, get_posture_create_resources,
+        {'name': name, 'type': check_type, 'action': action, 'description': description}
+    )
+    output, r = StdAPIUtils.format_output(j, outputFormat, DevicePostureTransformers.GetCreateAsCsv)
+    print(output)
+
+
+def item_update(outputFormat, sessionname, itemid, name, action, status, description):
+    j = StdAPIUtils.generic_api_call_handler(
+        sessionname, get_posture_update_resources,
+        {'itemid': itemid, 'name': name, 'action': action, 'status': status, 'description': description}
+    )
+    output, r = StdAPIUtils.format_output(j, outputFormat, DevicePostureTransformers.GetUpdateAsCsv)
+    print(output)
+
+
+def item_delete(outputFormat, sessionname, itemid):
+    j = StdAPIUtils.generic_api_call_handler(sessionname, get_posture_delete_resources, {'itemid': itemid})
+    output, r = StdAPIUtils.format_output(j, outputFormat, DevicePostureTransformers.GetDeleteAsCsv)
+    print(output)

--- a/logics/DevicePostureLogics.py
+++ b/logics/DevicePostureLogics.py
@@ -202,3 +202,87 @@ def item_delete(outputFormat, sessionname, itemid):
     j = StdAPIUtils.generic_api_call_handler(sessionname, get_posture_delete_resources, {'itemid': itemid})
     output, r = StdAPIUtils.format_output(j, outputFormat, DevicePostureTransformers.GetDeleteAsCsv)
     print(output)
+
+
+def get_device_posture_resources(token, JsonData):
+    Headers = StdAPIUtils.get_api_call_headers(token)
+    api_call_type = "POST"
+    variables = {"deviceID": JsonData['itemid']}
+
+    Body = """
+    query GetDevicePosture($deviceID: ID!) {
+        devicePosture(id: $deviceID) {
+            hardDriveEncryption {
+                isSatisfied
+                detected
+            }
+            screenLockPasscode {
+                isSatisfied
+                detected
+            }
+            firewall {
+                isSatisfied
+                detected
+            }
+            biometric {
+                isSatisfied
+                detected
+            }
+            antivirus {
+                isSatisfied
+                detected
+            }
+            osVersion {
+                isSatisfied
+                version
+            }
+            crowdstrike {
+                isVerified
+                failureReason
+                expiredAt
+                failureDetails
+            }
+            jamf {
+                isVerified
+                failureReason
+                expiredAt
+                failureDetails
+            }
+            kandji {
+                isVerified
+                failureReason
+                expiredAt
+                failureDetails
+            }
+            inTune {
+                isVerified
+                failureReason
+                expiredAt
+                failureDetails
+            }
+            sentinelOne {
+                isVerified
+                failureReason
+                expiredAt
+                failureDetails
+            }
+            onePassword {
+                isVerified
+                failureReason
+                expiredAt
+                failureDetails
+            }
+            manualVerification {
+                isVerified
+                value
+            }
+        }
+    }
+    """
+    return True, api_call_type, Headers, Body, variables
+
+
+def device_posture_check(outputFormat, sessionname, itemid):
+    j = StdAPIUtils.generic_api_call_handler(sessionname, get_device_posture_resources, {'itemid': itemid})
+    output, r = StdAPIUtils.format_output(j, outputFormat, DevicePostureTransformers.GetDevicePostureAsCsv)
+    print(output)

--- a/tgcli.py
+++ b/tgcli.py
@@ -1631,6 +1631,21 @@ posture_delete_parser = posture_subparsers.add_parser('delete')
 posture_delete_parser.set_defaults(func=posture_delete)
 posture_delete_parser.add_argument('-i', '--itemid', type=str, default="", help='posture check id', dest="ITEMID")
 
+# posture check — fetches live DevicePosture status for a specific device,
+# including all property checks (hardDriveEncryption, firewall, antivirus, etc.)
+# and TrustProviderVerification results (CrowdStrike, Jamf, Kandji, Intune,
+# SentinelOne, 1Password, manualVerification).
+def posture_check(args):
+    if not args.SESSIONNAME:
+        parser.error('no session name passed')
+    if not args.ITEMID:
+        parser.error('no device ID passed')
+    DevicePostureLogics.device_posture_check(args.OUTPUTFORMAT, args.SESSIONNAME, args.ITEMID)
+
+posture_check_parser = posture_subparsers.add_parser('check')
+posture_check_parser.set_defaults(func=posture_check)
+posture_check_parser.add_argument('-i', '--itemid', type=str, default="", help='device id', dest="ITEMID")
+
 #####
 # Mapping Parser
 # key <cmd>

--- a/tgcli.py
+++ b/tgcli.py
@@ -36,6 +36,7 @@ import SAccountKeysLogics
 import SecPoliciesLogics
 import MappingsLogics
 import DNSSecLogics
+import DevicePostureLogics
 
 VERSION="1.0.0"
 
@@ -1526,6 +1527,109 @@ def dnssec_deny_list_resources(args):
 dnssec_denylist_parser = dnssec_subparsers.add_parser('setDenyList')
 dnssec_denylist_parser.set_defaults(func=dnssec_deny_list_resources)
 dnssec_denylist_parser.add_argument('-d','--domains',type=str,default="", help='CSV list of domains', dest="CSVDOMAINS")
+
+#####
+#
+# Device Posture Parser
+# posture <list, show, create, update, delete>
+#
+#####
+
+POSTURE_TYPES = [
+    'OS_VERSION', 'ANTIVIRUS', 'FIREWALL', 'DISK_ENCRYPTION',
+    'SCREEN_LOCK', 'PROCESS', 'FILE', 'REGISTRY'
+]
+POSTURE_ACTIONS = ['ALLOW_ACCESS', 'BLOCK_ACCESS']
+POSTURE_STATUSES = ['ENABLED', 'DISABLED']
+
+# posture commands
+posture_parser = subparsers.add_parser('posture')
+posture_subparsers = posture_parser.add_subparsers()
+
+# posture list
+def posture_list(args):
+    if not args.SESSIONNAME:
+        parser.error('no session name passed')
+    DevicePostureLogics.item_list(args.OUTPUTFORMAT, args.SESSIONNAME)
+
+posture_list_parser = posture_subparsers.add_parser('list')
+posture_list_parser.set_defaults(func=posture_list)
+
+# posture show
+def posture_show(args):
+    if not args.SESSIONNAME:
+        parser.error('no session name passed')
+    if not args.ITEMID:
+        parser.error('no posture check ID passed')
+    DevicePostureLogics.item_show(args.OUTPUTFORMAT, args.SESSIONNAME, args.ITEMID)
+
+posture_show_parser = posture_subparsers.add_parser('show')
+posture_show_parser.set_defaults(func=posture_show)
+posture_show_parser.add_argument('-i', '--itemid', type=str, default="", help='posture check id', dest="ITEMID")
+
+# posture create
+def posture_create(args):
+    if not args.SESSIONNAME:
+        parser.error('no session name passed')
+    if not args.ITEMNAME:
+        parser.error('no name passed')
+    if not args.CHECKTYPE:
+        parser.error('no check type passed')
+    if args.CHECKTYPE.upper() not in POSTURE_TYPES:
+        parser.error('invalid check type. Valid types: ' + ', '.join(POSTURE_TYPES))
+    if not args.ACTION:
+        parser.error('no action passed')
+    if args.ACTION.upper() not in POSTURE_ACTIONS:
+        parser.error('invalid action. Valid actions: ' + ', '.join(POSTURE_ACTIONS))
+    DevicePostureLogics.item_create(
+        args.OUTPUTFORMAT, args.SESSIONNAME,
+        args.ITEMNAME, args.CHECKTYPE.upper(), args.ACTION.upper(), args.DESCRIPTION
+    )
+
+posture_create_parser = posture_subparsers.add_parser('create')
+posture_create_parser.set_defaults(func=posture_create)
+posture_create_parser.add_argument('-n', '--name', type=str, default="", help='posture check name', dest="ITEMNAME")
+posture_create_parser.add_argument('-t', '--type', type=str, default="", help='check type [' + '|'.join(POSTURE_TYPES) + ']', dest="CHECKTYPE")
+posture_create_parser.add_argument('-a', '--action', type=str, default="", help='action [' + '|'.join(POSTURE_ACTIONS) + ']', dest="ACTION")
+posture_create_parser.add_argument('-d', '--description', type=str, default="", help='(optional) description', dest="DESCRIPTION")
+
+# posture update
+def posture_update(args):
+    if not args.SESSIONNAME:
+        parser.error('no session name passed')
+    if not args.ITEMID:
+        parser.error('no posture check ID passed')
+    if args.ACTION and args.ACTION.upper() not in POSTURE_ACTIONS:
+        parser.error('invalid action. Valid actions: ' + ', '.join(POSTURE_ACTIONS))
+    if args.STATUS and args.STATUS.upper() not in POSTURE_STATUSES:
+        parser.error('invalid status. Valid statuses: ' + ', '.join(POSTURE_STATUSES))
+    DevicePostureLogics.item_update(
+        args.OUTPUTFORMAT, args.SESSIONNAME, args.ITEMID,
+        args.ITEMNAME,
+        args.ACTION.upper() if args.ACTION else "",
+        args.STATUS.upper() if args.STATUS else "",
+        args.DESCRIPTION
+    )
+
+posture_update_parser = posture_subparsers.add_parser('update')
+posture_update_parser.set_defaults(func=posture_update)
+posture_update_parser.add_argument('-i', '--itemid', type=str, default="", help='posture check id', dest="ITEMID")
+posture_update_parser.add_argument('-n', '--name', type=str, default="", help='new name', dest="ITEMNAME")
+posture_update_parser.add_argument('-a', '--action', type=str, default="", help='action [' + '|'.join(POSTURE_ACTIONS) + ']', dest="ACTION")
+posture_update_parser.add_argument('-s', '--status', type=str, default="", help='status [' + '|'.join(POSTURE_STATUSES) + ']', dest="STATUS")
+posture_update_parser.add_argument('-d', '--description', type=str, default="", help='description', dest="DESCRIPTION")
+
+# posture delete
+def posture_delete(args):
+    if not args.SESSIONNAME:
+        parser.error('no session name passed')
+    if not args.ITEMID:
+        parser.error('no posture check ID passed')
+    DevicePostureLogics.item_delete(args.OUTPUTFORMAT, args.SESSIONNAME, args.ITEMID)
+
+posture_delete_parser = posture_subparsers.add_parser('delete')
+posture_delete_parser.set_defaults(func=posture_delete)
+posture_delete_parser.add_argument('-i', '--itemid', type=str, default="", help='posture check id', dest="ITEMID")
 
 #####
 # Mapping Parser

--- a/transformers/DevicePostureTransformers.py
+++ b/transformers/DevicePostureTransformers.py
@@ -27,3 +27,85 @@ def GetUpdateAsCsv(jsonResults):
 def GetDeleteAsCsv(jsonResults):
     columns = ['ok', 'error']
     return GenericTransformers.GetUpdateAsCsvNoNesting(jsonResults, 'devicePostureCheckDelete', columns)
+
+
+def GetDevicePostureAsCsv(jsonResults):
+    posture = jsonResults['data']['devicePosture']
+
+    def prop(field):
+        """Flatten a DevicePropertyPostureCheck or OsVersionPostureCheck."""
+        if posture.get(field) is None:
+            return None, None
+        node = posture[field]
+        satisfied = node.get('isSatisfied')
+        # DevicePropertyPostureCheck has 'detected'; OsVersionPostureCheck has 'version'
+        detail = node.get('detected') if 'detected' in node else node.get('version')
+        return satisfied, detail
+
+    def trust(field):
+        """Flatten a TrustProviderVerification."""
+        if posture.get(field) is None:
+            return None, None, None, None
+        node = posture[field]
+        return (
+            node.get('isVerified'),
+            node.get('failureReason'),
+            node.get('expiredAt'),
+            node.get('failureDetails'),
+        )
+
+    def manual():
+        if posture.get('manualVerification') is None:
+            return None, None
+        node = posture['manualVerification']
+        return node.get('isVerified'), node.get('value')
+
+    hde_sat, hde_det   = prop('hardDriveEncryption')
+    slp_sat, slp_det   = prop('screenLockPasscode')
+    fw_sat,  fw_det    = prop('firewall')
+    bio_sat, bio_det   = prop('biometric')
+    av_sat,  av_det    = prop('antivirus')
+    os_sat,  os_ver    = prop('osVersion')
+    cs_ver,  cs_fr, cs_exp, cs_fd  = trust('crowdstrike')
+    jf_ver,  jf_fr, jf_exp, jf_fd  = trust('jamf')
+    kd_ver,  kd_fr, kd_exp, kd_fd  = trust('kandji')
+    it_ver,  it_fr, it_exp, it_fd  = trust('inTune')
+    s1_ver,  s1_fr, s1_exp, s1_fd  = trust('sentinelOne')
+    op_ver,  op_fr, op_exp, op_fd  = trust('onePassword')
+    mv_ver,  mv_val                = manual()
+
+    columns = [
+        'hardDriveEncryption.isSatisfied', 'hardDriveEncryption.detected',
+        'screenLockPasscode.isSatisfied',  'screenLockPasscode.detected',
+        'firewall.isSatisfied',            'firewall.detected',
+        'biometric.isSatisfied',           'biometric.detected',
+        'antivirus.isSatisfied',           'antivirus.detected',
+        'osVersion.isSatisfied',           'osVersion.version',
+        'crowdstrike.isVerified',   'crowdstrike.failureReason',   'crowdstrike.expiredAt',   'crowdstrike.failureDetails',
+        'jamf.isVerified',          'jamf.failureReason',          'jamf.expiredAt',          'jamf.failureDetails',
+        'kandji.isVerified',        'kandji.failureReason',        'kandji.expiredAt',        'kandji.failureDetails',
+        'inTune.isVerified',        'inTune.failureReason',        'inTune.expiredAt',        'inTune.failureDetails',
+        'sentinelOne.isVerified',   'sentinelOne.failureReason',   'sentinelOne.expiredAt',   'sentinelOne.failureDetails',
+        'onePassword.isVerified',   'onePassword.failureReason',   'onePassword.expiredAt',   'onePassword.failureDetails',
+        'manualVerification.isVerified', 'manualVerification.value',
+    ]
+
+    data = [[
+        hde_sat, hde_det,
+        slp_sat, slp_det,
+        fw_sat,  fw_det,
+        bio_sat, bio_det,
+        av_sat,  av_det,
+        os_sat,  os_ver,
+        cs_ver, cs_fr, cs_exp, cs_fd,
+        jf_ver, jf_fr, jf_exp, jf_fd,
+        kd_ver, kd_fr, kd_exp, kd_fd,
+        it_ver, it_fr, it_exp, it_fd,
+        s1_ver, s1_fr, s1_exp, s1_fd,
+        op_ver, op_fr, op_exp, op_fd,
+        mv_ver, mv_val,
+    ]]
+
+    df = pd.DataFrame(data, columns=columns)
+    pd.set_option('display.max_rows', None)
+    return df

--- a/transformers/DevicePostureTransformers.py
+++ b/transformers/DevicePostureTransformers.py
@@ -1,0 +1,29 @@
+import json
+import pandas as pd
+import logging
+import GenericTransformers
+
+
+def GetListAsCsv(jsonResults):
+    columns = ['id', 'name', 'description', 'type', 'action', 'status', 'createdAt', 'updatedAt']
+    return GenericTransformers.GetListAsCsv(jsonResults, columns)
+
+
+def GetShowAsCsv(jsonResults):
+    columns = ['id', 'name', 'description', 'type', 'action', 'status', 'createdAt', 'updatedAt']
+    return GenericTransformers.GetShowAsCsvNoNesting(jsonResults, 'devicePostureCheck', columns)
+
+
+def GetCreateAsCsv(jsonResults):
+    columns = ['ok', 'error', 'id', 'name', 'description', 'type', 'action', 'status']
+    return GenericTransformers.GetUpdateAsCsvNoNesting(jsonResults, 'devicePostureCheckCreate', columns)
+
+
+def GetUpdateAsCsv(jsonResults):
+    columns = ['ok', 'error', 'id', 'name', 'description', 'type', 'action', 'status']
+    return GenericTransformers.GetUpdateAsCsvNoNesting(jsonResults, 'devicePostureCheckUpdate', columns)
+
+
+def GetDeleteAsCsv(jsonResults):
+    columns = ['ok', 'error']
+    return GenericTransformers.GetUpdateAsCsvNoNesting(jsonResults, 'devicePostureCheckDelete', columns)


### PR DESCRIPTION
## Summary

- Adds a new `posture` top-level command group with subcommands to manage device posture check configuration (`list`, `show`, `create`, `update`, `delete`) and inspect live device posture status (`check`)
- Implements the `devicePosture(id)` GraphQL query, exposing all `DevicePosture` fields from the Twingate API including all `TrustProviderVerification` providers
- Adds corresponding logic, transformer, and CLI wiring following the existing patterns in the codebase

## What changed

**New files:**
- `logics/DevicePostureLogics.py` — GraphQL queries/mutations and public functions for all posture operations
- `transformers/DevicePostureTransformers.py` — CSV/DataFrame formatters, including a custom flattening transformer for the deeply nested `DevicePosture` response

**Modified files:**
- `tgcli.py` — registers the `posture` command group with all subcommands and argument definitions
- `README.md` — documents all new commands and includes usage examples

## New commands

| Command | Description |
|---|---|
| `posture list` | List all configured posture checks |
| `posture show -i <id>` | Show a specific posture check |
| `posture create -n <name> -t <type> -a <action>` | Create a posture check |
| `posture update -i <id> [-n name] [-a action] [-s status]` | Update a posture check |
| `posture delete -i <id>` | Delete a posture check |
| `posture check -i <device_id>` | Fetch live posture status for a device |

## `posture check` output fields

The `check` subcommand calls `devicePosture(id)` and returns all fields from the `DevicePosture` type:

- **Property checks** (`isSatisfied` + `detected`): `hardDriveEncryption`, `screenLockPasscode`, `firewall`, `biometric`, `antivirus`
- **OS version** (`isSatisfied` + `version`): `osVersion`
- **TrustProviderVerification** (`isVerified`, `failureReason`, `expiredAt`, `failureDetails`): `crowdstrike`, `jamf`, `kandji`, `inTune`, `sentinelOne`, `onePassword`
- **Manual verification** (`isVerified` + `value`): `manualVerification`

## Reviewer notes

- The `posture check` transformer is custom (not using the generic helpers) because the response nesting is too deep for `GetShowAsCsvNoNesting`
- `posture list/show/create/update/delete` target posture check *configuration* endpoints; `posture check` targets the separate `devicePosture(id)` query that returns a device's live posture state