### PR TITLE
Add posture check command with TrustProviderVerification support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A command-line interface for the [Twingate](https://www.twingate.com) Admin API.
   - [policy](#policy)
   - [dnssec](#dnssec)
   - [mappings](#mappings)
+  - [posture](#posture)
 - [Rate Limiting](#rate-limiting)
 - [Development](#development)
 
@@ -487,6 +488,35 @@ tgcli mappings user-resource-detail -e alice@example.com
 # Export all mappings to CSV
 tgcli -f CSV mappings user-resource
 ```
+
+---
+
+### posture
+
+Inspect the live posture status of a device. Returns all property checks and
+[TrustProviderVerification](https://www.twingate.com/docs/api#definition-TrustProviderVerification)
+results from the Twingate `devicePosture` API.
+
+```bash
+# Fetch live posture status for a device (JSON by default)
+tgcli posture check -i "RGV2aWNlOjIzODEwMDk="
+
+# Display as a DataFrame (easier to read in the terminal)
+tgcli -f DF posture check -i "RGV2aWNlOjIzODEwMDk="
+```
+
+**Output fields:**
+
+| Category | Fields |
+|---|---|
+| Property checks | `hardDriveEncryption`, `screenLockPasscode`, `firewall`, `biometric`, `antivirus` — each with `isSatisfied` + `detected` |
+| OS version | `osVersion.isSatisfied`, `osVersion.version` |
+| TrustProviderVerification | `crowdstrike`, `jamf`, `kandji`, `inTune`, `sentinelOne`, `onePassword` — each with `isVerified`, `failureReason`, `expiredAt`, `failureDetails` |
+| Manual | `manualVerification.isVerified`, `manualVerification.value` |
+
+`isSatisfied` values: `YES`, `NO`, `NOT_REQUIRED`
+
+`failureReason` values: `VERIFICATION_FAILED`, `VERIFICATION_EXPIRED`, `NO_SERIAL_NUMBER`, `NOT_DETECTED`, `MISSING_DATA`
 
 ---
 

--- a/src/tgcli/commands/posture.py
+++ b/src/tgcli/commands/posture.py
@@ -1,0 +1,25 @@
+"""Device posture commands."""
+
+from __future__ import annotations
+
+import typer
+
+from tgcli.commands._common import get_client, run_query
+from tgcli.output.transformers import posture as t
+from tgcli.queries import posture as q
+
+app = typer.Typer(help="Inspect Device Posture status.")
+
+
+@app.command("check")
+def posture_check(
+    itemid: str = typer.Option(..., "-i", "--itemid", help="Device ID."),
+) -> None:
+    """Fetch the live posture status of a device.
+
+    Returns all property checks (hardDriveEncryption, screenLockPasscode,
+    firewall, biometric, antivirus, osVersion) and TrustProviderVerification
+    results for CrowdStrike, Jamf, Kandji, Intune, SentinelOne, 1Password,
+    and manual verification.
+    """
+    run_query(get_client(), q.DEVICE_POSTURE_CHECK, {"deviceID": itemid}, t.get_device_posture_as_csv)

--- a/src/tgcli/main.py
+++ b/src/tgcli/main.py
@@ -81,6 +81,7 @@ def _register_commands() -> None:
         mappings,
         networks,
         policies,
+        posture,
         resources,
         accounts,
         users,
@@ -98,6 +99,7 @@ def _register_commands() -> None:
     app.add_typer(policies.app, name="policy")
     app.add_typer(dnssec.app, name="dnssec")
     app.add_typer(mappings.app, name="mappings")
+    app.add_typer(posture.app, name="posture")
 
 
 _register_commands()

--- a/src/tgcli/output/transformers/posture.py
+++ b/src/tgcli/output/transformers/posture.py
@@ -1,0 +1,81 @@
+"""Device posture data transformers."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def _prop(node: dict | None, detail_key: str):
+    """Flatten a DevicePropertyPostureCheck or OsVersionPostureCheck."""
+    if node is None:
+        return None, None
+    return node.get("isSatisfied"), node.get(detail_key)
+
+
+def _trust(node: dict | None):
+    """Flatten a TrustProviderVerification."""
+    if node is None:
+        return None, None, None, None
+    return (
+        node.get("isVerified"),
+        node.get("failureReason"),
+        node.get("expiredAt"),
+        node.get("failureDetails"),
+    )
+
+
+def get_device_posture_as_csv(json_results: dict) -> pd.DataFrame:
+    posture = json_results["data"]["devicePosture"]
+
+    hde_sat, hde_det = _prop(posture.get("hardDriveEncryption"), "detected")
+    slp_sat, slp_det = _prop(posture.get("screenLockPasscode"), "detected")
+    fw_sat,  fw_det  = _prop(posture.get("firewall"), "detected")
+    bio_sat, bio_det = _prop(posture.get("biometric"), "detected")
+    av_sat,  av_det  = _prop(posture.get("antivirus"), "detected")
+    os_sat,  os_ver  = _prop(posture.get("osVersion"), "version")
+
+    cs_ver, cs_fr, cs_exp, cs_fd = _trust(posture.get("crowdstrike"))
+    jf_ver, jf_fr, jf_exp, jf_fd = _trust(posture.get("jamf"))
+    kd_ver, kd_fr, kd_exp, kd_fd = _trust(posture.get("kandji"))
+    it_ver, it_fr, it_exp, it_fd = _trust(posture.get("inTune"))
+    s1_ver, s1_fr, s1_exp, s1_fd = _trust(posture.get("sentinelOne"))
+    op_ver, op_fr, op_exp, op_fd = _trust(posture.get("onePassword"))
+
+    mv = posture.get("manualVerification")
+    mv_ver = mv.get("isVerified") if mv else None
+    mv_val = mv.get("value") if mv else None
+
+    columns = [
+        "hardDriveEncryption.isSatisfied", "hardDriveEncryption.detected",
+        "screenLockPasscode.isSatisfied",  "screenLockPasscode.detected",
+        "firewall.isSatisfied",            "firewall.detected",
+        "biometric.isSatisfied",           "biometric.detected",
+        "antivirus.isSatisfied",           "antivirus.detected",
+        "osVersion.isSatisfied",           "osVersion.version",
+        "crowdstrike.isVerified",  "crowdstrike.failureReason",  "crowdstrike.expiredAt",  "crowdstrike.failureDetails",
+        "jamf.isVerified",         "jamf.failureReason",         "jamf.expiredAt",         "jamf.failureDetails",
+        "kandji.isVerified",       "kandji.failureReason",       "kandji.expiredAt",       "kandji.failureDetails",
+        "inTune.isVerified",       "inTune.failureReason",       "inTune.expiredAt",       "inTune.failureDetails",
+        "sentinelOne.isVerified",  "sentinelOne.failureReason",  "sentinelOne.expiredAt",  "sentinelOne.failureDetails",
+        "onePassword.isVerified",  "onePassword.failureReason",  "onePassword.expiredAt",  "onePassword.failureDetails",
+        "manualVerification.isVerified", "manualVerification.value",
+    ]
+
+    data = [[
+        hde_sat, hde_det,
+        slp_sat, slp_det,
+        fw_sat,  fw_det,
+        bio_sat, bio_det,
+        av_sat,  av_det,
+        os_sat,  os_ver,
+        cs_ver, cs_fr, cs_exp, cs_fd,
+        jf_ver, jf_fr, jf_exp, jf_fd,
+        kd_ver, kd_fr, kd_exp, kd_fd,
+        it_ver, it_fr, it_exp, it_fd,
+        s1_ver, s1_fr, s1_exp, s1_fd,
+        op_ver, op_fr, op_exp, op_fd,
+        mv_ver, mv_val,
+    ]]
+
+    pd.set_option("display.max_rows", None)
+    return pd.DataFrame(data, columns=columns)

--- a/src/tgcli/queries/posture.py
+++ b/src/tgcli/queries/posture.py
@@ -1,0 +1,74 @@
+"""GraphQL queries for device posture."""
+
+from __future__ import annotations
+
+DEVICE_POSTURE_CHECK = """
+query GetDevicePosture($deviceID: ID!) {
+  devicePosture(id: $deviceID) {
+    hardDriveEncryption {
+      isSatisfied
+      detected
+    }
+    screenLockPasscode {
+      isSatisfied
+      detected
+    }
+    firewall {
+      isSatisfied
+      detected
+    }
+    biometric {
+      isSatisfied
+      detected
+    }
+    antivirus {
+      isSatisfied
+      detected
+    }
+    osVersion {
+      isSatisfied
+      version
+    }
+    crowdstrike {
+      isVerified
+      failureReason
+      expiredAt
+      failureDetails
+    }
+    jamf {
+      isVerified
+      failureReason
+      expiredAt
+      failureDetails
+    }
+    kandji {
+      isVerified
+      failureReason
+      expiredAt
+      failureDetails
+    }
+    inTune {
+      isVerified
+      failureReason
+      expiredAt
+      failureDetails
+    }
+    sentinelOne {
+      isVerified
+      failureReason
+      expiredAt
+      failureDetails
+    }
+    onePassword {
+      isVerified
+      failureReason
+      expiredAt
+      failureDetails
+    }
+    manualVerification {
+      isVerified
+      value
+    }
+  }
+}
+"""


### PR DESCRIPTION
## Summary

Adds a `posture check` command that fetches the live posture status of a device via the `devicePosture(id)` GraphQL query, exposing all `DevicePosture` fields including `TrustProviderVerification` results for all supported providers.

## What changed

**New files:**
- `src/tgcli/queries/posture.py` — `DEVICE_POSTURE_CHECK` GraphQL query with all `DevicePosture` fields
- `src/tgcli/output/transformers/posture.py` — custom flattening transformer for the nested `DevicePosture` response
- `src/tgcli/commands/posture.py` — Typer command group with `check` subcommand

**Modified files:**
- `src/tgcli/main.py` — registers the `posture` command group
- `README.md` — adds `posture` to the table of contents and documents the command with output field reference table

## New command

```bash
tgcli posture check -i <device_id>
tgcli -f DF posture check -i <device_id>
```

## Output fields

| Category | Fields |
|---|---|
| Property checks | `hardDriveEncryption`, `screenLockPasscode`, `firewall`, `biometric`, `antivirus` — each with `isSatisfied` + `detected` |
| OS version | `osVersion.isSatisfied`, `osVersion.version` |
| TrustProviderVerification | `crowdstrike`, `jamf`, `kandji`, `inTune`, `sentinelOne`, `onePassword` — each with `isVerified`, `failureReason`, `expiredAt`, `failureDetails` |
| Manual | `manualVerification.isVerified`, `manualVerification.value` |

## Reviewer notes

- The transformer is custom (not using generic helpers) because the `DevicePosture` response nesting is deeper than the generic helpers support
- Provider fields (`crowdstrike`, `jamf`, etc.) return `null` when the platform doesn't support that provider or the integration isn't configured — the transformer handles this gracefully
- Schema reference: https://www.twingate.com/docs/api#definition-DevicePosture