### PR TITLE
Add key list/expiring commands and account rename/listKeys

### DIFF
--- a/src/tgcli/commands/accounts.py
+++ b/src/tgcli/commands/accounts.py
@@ -73,3 +73,20 @@ def account_remove_resources(
         {"id": itemid, "resourceIDS": split_ids(resourceids)},
         t.get_add_remove_resources_as_csv,
     )
+
+
+@app.command("rename")
+def account_rename(
+    itemid: str = typer.Option(..., "-i", "--itemid", help="Service Account ID."),
+    name: str = typer.Option(..., "-n", "--name", help="New Service Account name."),
+) -> None:
+    """Rename a Service Account."""
+    run_query(get_client(), q.RENAME_ACCOUNT, {"id": itemid, "name": name}, t.get_rename_as_csv)
+
+
+@app.command("listKeys")
+def account_list_keys(
+    itemid: str = typer.Option(..., "-i", "--itemid", help="Service Account ID."),
+) -> None:
+    """List all keys for a specific Service Account."""
+    run_query(get_client(), q.LIST_ACCOUNT_KEYS, {"itemID": itemid}, t.get_list_keys_as_csv)

--- a/src/tgcli/commands/keys.py
+++ b/src/tgcli/commands/keys.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Optional
+
 import typer
 
-from tgcli.commands._common import get_client, run_query
+from tgcli.commands._common import get_client, run_paginated, run_query
 from tgcli.output.transformers import keys as t
 from tgcli.queries import keys as q
 from tgcli.validators.key import validate_key_expiration
@@ -59,3 +61,38 @@ def key_rename(
 ) -> None:
     """Rename a Service Account Key."""
     run_query(get_client(), q.RENAME_KEY, {"id": itemid, "name": name}, t.get_rename_as_csv)
+
+
+@app.command("list")
+def key_list(
+    status: Optional[str] = typer.Option(
+        None, "-s", "--status",
+        help="Filter by status: ACTIVE, REVOKED, or EXPIRED.",
+    ),
+) -> None:
+    """List all Service Account Keys across all Service Accounts."""
+    status_upper = status.upper() if status else None
+    valid_statuses = {"ACTIVE", "REVOKED", "EXPIRED"}
+    if status_upper and status_upper not in valid_statuses:
+        typer.echo(f"Error: --status must be one of {sorted(valid_statuses)}.", err=True)
+        raise typer.Exit(1)
+
+    def transformer(json_results: list) -> "pd.DataFrame":  # type: ignore[name-defined]
+        return t.get_list_as_csv(json_results, status_filter=status_upper)
+
+    run_paginated(get_client(), q.LIST_KEYS, "serviceAccounts", transformer)
+
+
+@app.command("expiring")
+def key_expiring(
+    days: int = typer.Option(30, "-d", "--days", help="Warn for keys expiring within this many days."),
+) -> None:
+    """List active keys expiring within a given number of days."""
+    if days < 0:
+        typer.echo("Error: --days must be a non-negative integer.", err=True)
+        raise typer.Exit(1)
+
+    def transformer(json_results: list) -> "pd.DataFrame":  # type: ignore[name-defined]
+        return t.get_list_as_csv(json_results, status_filter="ACTIVE", expiring_days=days)
+
+    run_paginated(get_client(), q.LIST_KEYS, "serviceAccounts", transformer)

--- a/src/tgcli/output/transformers/accounts.py
+++ b/src/tgcli/output/transformers/accounts.py
@@ -30,3 +30,23 @@ def get_delete_as_csv(json_results: dict) -> pd.DataFrame:
 def get_add_remove_resources_as_csv(json_results: dict) -> pd.DataFrame:
     columns = ["ok", "error", "id", "name", "resources"]
     return generic.get_update_as_csv_no_nesting(json_results, "serviceAccountUpdate", columns)
+
+
+def get_rename_as_csv(json_results: dict) -> pd.DataFrame:
+    columns = ["ok", "error", "id", "name"]
+    return generic.get_update_as_csv_no_nesting(json_results, "serviceAccountUpdate", columns)
+
+
+def get_list_keys_as_csv(json_results: dict) -> pd.DataFrame:
+    """Return all keys for a single service account as a flat DataFrame."""
+    import pandas as pd
+    columns = ["id", "name", "status", "createdAt", "expiresAt", "revokedAt"]
+    item = json_results["data"]["serviceAccount"]
+    rows = []
+    if item:
+        for edge in item.get("keys", {}).get("edges", []):
+            key = edge["node"]
+            if key:
+                rows.append([key.get(c, "") for c in columns])
+    pd.set_option("display.max_rows", None)
+    return pd.DataFrame(rows, columns=columns)

--- a/src/tgcli/output/transformers/keys.py
+++ b/src/tgcli/output/transformers/keys.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from typing import Any
+
 import pandas as pd
 
 from tgcli.output.transformers import generic
@@ -30,3 +33,58 @@ def get_revoke_as_csv(json_results: dict) -> pd.DataFrame:
 def get_rename_as_csv(json_results: dict) -> pd.DataFrame:
     columns = ["ok", "error", "id", "name"]
     return generic.get_update_as_csv_no_nesting(json_results, "serviceAccountKeyUpdate", columns)
+
+
+def get_list_as_csv(
+    json_results: list,
+    status_filter: str | None = None,
+    expiring_days: int | None = None,
+) -> pd.DataFrame:
+    """Flatten all keys from all service accounts into a single DataFrame.
+
+    Optionally filter by status or by keys expiring within a given number of days.
+    """
+    columns = ["serviceAccountId", "serviceAccountName", "id", "name", "status", "createdAt", "expiresAt", "revokedAt"]
+    rows: list[list[Any]] = []
+    now = datetime.now(tz=timezone.utc)
+
+    for page in json_results:
+        for edge in page:
+            account = edge["node"]
+            if account is None:
+                continue
+            sa_id = account.get("id", "")
+            sa_name = account.get("name", "")
+            for key_edge in account.get("keys", {}).get("edges", []):
+                key = key_edge["node"]
+                if key is None:
+                    continue
+
+                if status_filter and key.get("status") != status_filter:
+                    continue
+
+                if expiring_days is not None:
+                    expires_at = key.get("expiresAt")
+                    if not expires_at:
+                        continue
+                    try:
+                        expiry = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+                    except ValueError:
+                        continue
+                    delta = (expiry - now).days
+                    if delta < 0 or delta > expiring_days:
+                        continue
+
+                rows.append([
+                    sa_id,
+                    sa_name,
+                    key.get("id", ""),
+                    key.get("name", ""),
+                    key.get("status", ""),
+                    key.get("createdAt", ""),
+                    key.get("expiresAt", ""),
+                    key.get("revokedAt", ""),
+                ])
+
+    pd.set_option("display.max_rows", None)
+    return pd.DataFrame(rows, columns=columns)

--- a/src/tgcli/queries/accounts.py
+++ b/src/tgcli/queries/accounts.py
@@ -141,3 +141,37 @@ mutation removeResToSAccount($id: ID!, $resourceIDS: [ID!]) {
   }
 }
 """
+
+RENAME_ACCOUNT = """
+mutation ObjRename($id: ID!, $name: String!) {
+  serviceAccountUpdate(id: $id, name: $name) {
+    ok
+    error
+    entity {
+      id
+      name
+    }
+  }
+}
+"""
+
+LIST_ACCOUNT_KEYS = """
+query getObj($itemID: ID!) {
+  serviceAccount(id: $itemID) {
+    id
+    name
+    keys {
+      edges {
+        node {
+          id
+          name
+          status
+          createdAt
+          expiresAt
+          revokedAt
+        }
+      }
+    }
+  }
+}
+"""

--- a/src/tgcli/queries/keys.py
+++ b/src/tgcli/queries/keys.py
@@ -71,3 +71,32 @@ mutation ObjRename($id: ID!, $name: String!) {
   }
 }
 """
+
+LIST_KEYS = """
+query ListKeys($cursor: String) {
+  serviceAccounts(first: 100, after: $cursor) {
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    edges {
+      node {
+        id
+        name
+        keys {
+          edges {
+            node {
+              id
+              name
+              status
+              createdAt
+              expiresAt
+              revokedAt
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""


### PR DESCRIPTION
## Summary

- **`tgcli key list`** — flat list of all Service Account Keys across all Service Accounts, with an optional `--status` filter (`ACTIVE`, `REVOKED`, `EXPIRED`)
- **`tgcli key expiring`** — lists active keys expiring within N days (default 30); keys with no expiry date are excluded
- **`tgcli account rename`** — rename a Service Account by ID
- **`tgcli account listKeys`** — list all keys for a specific Service Account (scoped, flat output)

## Changes

| File | Change |
|---|---|
| `src/tgcli/queries/keys.py` | Added `LIST_KEYS` paginated query |
| `src/tgcli/queries/accounts.py` | Added `RENAME_ACCOUNT`, `LIST_ACCOUNT_KEYS` queries |
| `src/tgcli/output/transformers/keys.py` | Added `get_list_as_csv` with status + expiry filtering |
| `src/tgcli/output/transformers/accounts.py` | Added `get_rename_as_csv`, `get_list_keys_as_csv` |
| `src/tgcli/commands/keys.py` | Added `key list`, `key expiring` commands |
| `src/tgcli/commands/accounts.py` | Added `account rename`, `account listKeys` commands |

## Test plan

- [ ] `tgcli key list` returns all keys across all service accounts
- [ ] `tgcli key list --status ACTIVE` returns only active keys
- [ ] `tgcli key list --status REVOKED` returns only revoked keys
- [ ] `tgcli key expiring` returns active keys expiring within 30 days
- [ ] `tgcli key expiring --days 7` returns active keys expiring within 7 days
- [ ] `tgcli key expiring` excludes keys with no expiry date
- [ ] `tgcli account rename -i <id> -n <name>` renames the service account
- [ ] `tgcli account listKeys -i <id>` lists only keys for that account
- [ ] All commands support `-f CSV`, `-f DF`, and `-f JSON` output formats
- [ ] Invalid `--status` value exits with a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)